### PR TITLE
C 拡張外すために lxml から html5lib に変えてみた

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,3 +1,3 @@
 beautifulsoup4==4.5.3
-lxml==3.7.3
+html5lib==0.999999999
 requests==2.13.0

--- a/scrape.py
+++ b/scrape.py
@@ -85,7 +85,7 @@ def get_user(user):
         response = requests.get('http://wonderfl.net/user/%s/codes?page=%d' % (user, page), headers=headers)
         if index_template is None:
             index_template = response.text
-        soup = BeautifulSoup(response.text, 'lxml')
+        soup = BeautifulSoup(response.text, 'html5lib')
         codes = soup.select('.unitCode')
         if len(codes) is 0:
             break
@@ -95,7 +95,7 @@ def get_user(user):
 
     urls = [x.select_one('.ttl a')['href'] for x in all_unit_codes]
 
-    soup = BeautifulSoup(index_template, 'lxml')
+    soup = BeautifulSoup(index_template, 'html5lib')
 
     group = soup.select_one('.unitCodeGroup')
     group.clear()
@@ -128,7 +128,7 @@ def get_code_page(url):
 
     response = requests.get(url, headers={'accept-language': 'ja'})
 
-    soup = BeautifulSoup(response.text, 'lxml')
+    soup = BeautifulSoup(response.text, 'html5lib')
     swf_url = soup.find(content=re.compile('http:\/\/swf\.wonderfl\.net\/swf'))['content']
     swf_path = swf_url[24:]
     swf_dir = os.path.dirname(swf_path)


### PR DESCRIPTION
lxml が C 拡張含んでて、インスコに libxml2 とか libxslt が必要でハードルが高いかもと思って、
C 拡張含まないパッケージだけでイケるようにしてみましたー。

どれほど需要があるのかはわかんないですが、
インスコビリティは高いほうが良いかと思ってやってみましたー。