### PR TITLE
Add support for fullscreen preview

### DIFF
--- a/wonderfl.net/css/common.css
+++ b/wonderfl.net/css/common.css
@@ -2497,3 +2497,17 @@ body #main div.ad_super_bnr .adCmking dl dt {
 	cursor: pointer;
 	background-repeat: no-repeat;
 }
+
+/* --------------------------------------------------
+  support for js fullscreen
+-------------------------------------------------- */
+body.fullscreen #swf_container{
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 100;
+  width: 100%;
+  height: 100%;
+}

--- a/wonderfl.net/js/wonderfl.js
+++ b/wonderfl.net/js/wonderfl.js
@@ -1200,6 +1200,15 @@ Wonderfl.Codepage = new function() {
 
             // talk
             this.init_talk();
+
+            // override 'Preview Fullscreen' link
+            var swfFullscreenLinks = $$(".codeswf .btnFullScreen a")
+            if (swfFullscreenLinks.length === 1) {
+              swfFullscreenLinks[0].on('click', function(e) {
+                e.preventDefault()
+                Wonderfl.Codepage.fullscreen()
+              })
+            }
         },
         reload_swf : function() {
             this.play();
@@ -1216,6 +1225,18 @@ Wonderfl.Codepage = new function() {
             if ( Wonderfl.Codepage.reload_button ) {
                 Wonderfl.Codepage.reload_button.show();
             }
+        },
+        fullscreen : function() {
+            Wonderfl.Codepage.play();
+
+            var swf = document.getElementById('externalFlashContent')
+            swf.setAttribute('width', '100%')
+            swf.setAttribute('height', '100%')
+
+            var body = document.body
+            body.classList.add('fullscreen');
+            body.appendChild(document.getElementById('swf_container'))
+            body.removeChild(document.getElementById('container'))
         },
         add_button_listeners : function() {
             this.play_button   = $('btnPlay');


### PR DESCRIPTION
# フルスクリーン表示をクライアントサイドで実装

before | after
--- | ---
![before](https://cloud.githubusercontent.com/assets/1443118/24448249/83d25094-14ae-11e7-83e9-66ae8bb18694.gif)|![after](https://cloud.githubusercontent.com/assets/1443118/24448253/87383a8c-14ae-11e7-8d27-3ed01f44b311.gif)


## 本件で対応する課題

wonderflではフルスクリーン表示用のページでレンダする仕様であり、本アーカイブではそのページまで取得していないのでクライアントサイドで実装するようにした

## 課題に対する実装

aリンクに対しJSを追加し、押下時にDOMとstyleを変更してフルスクリーン表示を実装

## 対応していない点

- フルスクリーンから戻る機能（ページをリロードで対応）
- 右下のstop, reloadボタン
- コード側のフルスクリーン表示
